### PR TITLE
Update search-buffer-lines.vim

### DIFF
--- a/src/search-buffer-lines.vim
+++ b/src/search-buffer-lines.vim
@@ -3,7 +3,7 @@
 command! FZFLines call fzf#run({
   \ 'source':  BuffersLines(),
   \ 'sink':    function('LineHandler'),
-  \ 'options': '--extended --nth=3..,',
+  \ 'options': '--extended --nth=3..',
   \ 'tmux_height': '60%'
 \})
 


### PR DESCRIPTION
Fix `--nth` option as the extra comma is no longer allowed in Go version of fzf.
